### PR TITLE
Demonstrating using chembl_downloader to get SDF path

### DIFF
--- a/_notebooks/2021-12-20-substructlibrary-search-order.ipynb
+++ b/_notebooks/2021-12-20-substructlibrary-search-order.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "source": [
     "Here's the code to build the `SubstructLibrary` from the sdf file distributed by the ChEMBL team. \n",
-    "This uses a feature added in RDKit v2021.09 to allow a molecule key (or name) to be stored with the molecules in a `SubstructLibrary`.\n",
+    "This uses a feature added in RDKit v2021.09 to allow a molecule key (or name) to be stored with the molecules in a `SubstructLibrary`. Note you'll need to `pip install chembl_downloader` to run this block.\n",
     "\n",
     "Executing this takes about 45 minutes on my machine."
    ]

--- a/_notebooks/2021-12-20-substructlibrary-search-order.ipynb
+++ b/_notebooks/2021-12-20-substructlibrary-search-order.ipynb
@@ -67,9 +67,11 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```python\n",
+    "import chembl_downloader\n",
     "RDLogger.DisableLog(\"rdApp.warning\")\n",
     "\n",
     "molholder = rdSubstructLibrary.CachedTrustedSmilesMolHolder()\n",
@@ -79,7 +81,8 @@
     "keys = rdSubstructLibrary.KeyFromPropHolder() \n",
     "slib = rdSubstructLibrary.SubstructLibrary(molholder,patts,keys)\n",
     "t1 = time.time()\n",
-    "with gzip.GzipFile('/home/glandrum/Downloads/chembl_29.sdf.gz') as gz, Chem.ForwardSDMolSupplier(gz) as suppl:\n",
+    "sdf_path = chembl_downloader.download_sdf(version=\"29\")\n",
+    "with gzip.open(sdf_path) as gz, Chem.ForwardSDMolSupplier(gz) as suppl:\n",
     "    nDone = 0\n",
     "    for m in suppl:\n",
     "        if m is None:\n",
@@ -96,7 +99,7 @@
     "print(f'That took {time.time()-t1:.2f}s in total.')\n",
     "with open('./results/chembl29_ssslib.pkl','wb+') as outf:\n",
     "    pickle.dump(slib,outf)\n",
-    "    "
+    "```"
    ]
   },
   {


### PR DESCRIPTION
As a follow-up to this twitter discussion

<blockquote class="twitter-tweet" data-partner="tweetdeck"><p lang="en" dir="ltr">Really cool post, but I wish it were possible to directly re-run it (there are local file paths to ChEMBL data and no automation for downloading)<br><br>Solution: I added the generation of the substructure library as an extra function in `chembl_downloader`:<a href="https://t.co/MgiChnrxaj">https://t.co/MgiChnrxaj</a></p>&mdash; Charles Tapley Hoyt (@cthoyt) <a href="https://twitter.com/cthoyt/status/1472990952730079240?ref_src=twsrc%5Etfw">December 20, 2021</a></blockquote>

this PR makes a small change to automate the download of the ChEMBL SDF file using the lightweight [`chembl_downloader`](https://github.com/cthoyt/chembl-downloader) package. It chooses a file path that's deterministic on all systems so it can abstract away the need for a local file path for the ChEMBL SDF file.

It would also be possible to replace the whole line `with gzip.open(sdf_path) as gz, Chem.ForwardSDMolSupplier(gz) as suppl:` with `with chembl_downloader.supplier(version="29") as suppl:`, but I think that would be a bit too esoteric.